### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,17 @@ Database query logging will slow down your application, so this command is inten
 ## Getting started
 Get and install your db log command
 
-        ddev get chromatichq/ddev-dblog
+For DDEV v1.23.5 or above run
+
+```sh
+ddev add-on get chromatichq/ddev-dblog
+```
+
+For earlier versions of DDEV run
+
+```sh
+ddev get chromatichq/ddev-dblog
+```
 
 ## Using dblog
 
@@ -29,26 +39,31 @@ Get and install your db log command
 
 To follow the logs live (tail), do
 
-        ddev dblog tail
+```sh
+ddev dblog tail
+```
 
 which will tail the log file right in your current terminal window. `ctrl+c` to quit. When you quit tailing, the db query log is turned off automatically.
 
 ### Turn on db query logging
 If you just want to turn on the logging so you can capture a bunch of output and examine it later, do
 
-        ddev dblog on
+```sh
+ddev dblog on
+```
 
 You can find the logs in your db service at /tmp/dblog. Use
 
-        ddev ssh -s db
-        less /tmp/dblog
+```sh
+ddev ssh -s db
+less /tmp/dblog
+```
 
 to page through it or search it.
 
 ### Turn off db query logging
 Remember to turn off the db query logging. The logging is a drain on your application performance.
 
-        ddev dblog off
-
-
-
+```sh
+ddev dblog off
+```


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.