### PR TITLE
Update project to comply with latest DDEV add on standards

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{bats,sh,yml,yaml}]
+indent_size = 2

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 # Exclude files from releases/tarballs
 tests/ export-ignore
+.editorconfig export-ignore
 .github/ export-ignore
 .gitattributes export-ignore

--- a/install.yaml
+++ b/install.yaml
@@ -5,8 +5,7 @@ name: ddev-dblog
 global_files:
   - commands/db/dblog
 
-ddev_version_constraint: '>= v1.23.5'
-#ddev_version_constraint: '>= v1.24.10'
+ddev_version_constraint: '>= v1.24.10'
 
 # DDEV environment variables can be interpolated into these actions
 # post_install_actions:


### PR DESCRIPTION
## The Issue

During a run of `addon-update-checker.sh`, the following issues were identified:
 - install.yaml should contain `ddev_version_constraint: '>= v1.24.10'` or higher, see upstream file https://github.com/ddev/ddev-addon-template/blob/main/install.yaml
 - .gitattributes should contain '.editorconfig', see upstream file https://github.com/ddev/ddev-addon-template/blob/main/.gitattributes
 - .editorconfig is missing, see upstream file https://github.com/ddev/ddev-addon-template/blob/main/.editorconfig

## How This PR Solves The Issue

Changes version number and sets up editor config and git attributes as requested.

## Manual Testing Instructions

```
git checkout <this branch>
curl -fsSL https://ddev.com/s/addon-update-checker.sh | bash
```

You should see no errors reported.